### PR TITLE
Detect path to binary for VCS callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,7 @@ xprompt --help
 ## Usage
 
 To use `xprompt` to set your Bash prompt, add the following to your `.bashrc` or
-`.bash_profile` files in your home directory. NOTE: `xprompt` must be available on
-your `PATH` in order to work due to the specifics of how version control information
-is generated.
+`.bash_profile` files in your home directory.
 
 ```
 export PS1="$(xprompt ps1)"


### PR DESCRIPTION
Detect path to the binary for emitting VCS callback code
instead of requiring that `xprompt` is on the `PATH`

Fixes #3